### PR TITLE
fixed built_in cd

### DIFF
--- a/includes/shell.h
+++ b/includes/shell.h
@@ -237,6 +237,7 @@ void	remove_env_nodes(t_shell *mini, char *unset);
 int		builtin_unset(t_shell *mini);
 int		builtin_env(t_shell *mini);
 int		builtin_pwd(void);
+int		home_not_set(char *oldpwd);
 
 /**
  * Built_in echo

--- a/srcs/built_in.c
+++ b/srcs/built_in.c
@@ -87,7 +87,7 @@ int	print_cd_error(char *path, char *oldpwd)
 
 int	try_change_dir(t_shell *mini, char *target, char *oldpwd)
 {
-	char *newpwd;
+	char	*newpwd;
 
 	if (chdir(target) != 0)
 		return (print_cd_error(target, oldpwd));
@@ -97,7 +97,6 @@ int	try_change_dir(t_shell *mini, char *target, char *oldpwd)
 	free(oldpwd);
 	return (0);
 }
-
 
 /*
 * Implements the `cd` built-in command.
@@ -129,14 +128,12 @@ int	builtin_cd(t_shell *mini)
 	if (!mini->cmds->args[1])
 	{
 		if (!home || !home[0])
-		{
-			printf("cd: HOME not set\n");
-			free(oldpwd);
-			return (1);
-		}
+			return (home_not_set(oldpwd));
 		if (chdir(home) != 0)
 			return (print_cd_error(home, oldpwd));
 		newpwd = getcwd(NULL, 0);
+		if (!newpwd)
+			return (1);
 		updatewd(mini, newpwd, oldpwd);
 		free(oldpwd);
 		free(newpwd);

--- a/srcs/help2.c
+++ b/srcs/help2.c
@@ -85,3 +85,10 @@ char	*string_build(char *s1, char *s2)
 	free(s1);
 	return (joined);
 }
+
+int	home_not_set(char *oldpwd)
+{
+	printf("cd: HOME not set\n");
+	free(oldpwd);
+	return (1);
+}


### PR DESCRIPTION
fixed cd builtin to free all the getcwd results so no leaks. needed to make a small helper function for norminette purposes, and that i put into help2.c